### PR TITLE
feat: add Google Places recommendations and manual location search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 Project/.venv/
 bitescout_backend/instance/
 run_bitescout_demo.sh
+.env

--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ http://127.0.0.1:5000/
 http://127.0.0.1:5000/login.html
 http://127.0.0.1:5000/signup.html
 http://127.0.0.1:5000/browse.html
+http://127.0.0.1:5000/recommendations.html

--- a/bitescout_frontend/js/app.js
+++ b/bitescout_frontend/js/app.js
@@ -3,6 +3,7 @@
     userLocation: 'bitescout_user_location'
   };
 
+
   const data = window.BiteScoutData || { restaurants: [], sampleUsers: [], sampleReviews: [] };
 
   const App = {
@@ -80,6 +81,153 @@
       return this.state.favourites;
     },
 
+    initRecommendations() {
+      const target = document.getElementById('recommendationsGrid');
+      const detectBtn = document.getElementById('detectLocationBtn');
+      const searchBtn = document.getElementById('searchLocationBtn');
+      const resetBtn = document.getElementById('resetRecommendationsBtn');
+      const manualInput = document.getElementById('manualLocationInput');
+      const radiusSelect = document.getElementById('recommendationRadius');
+      const typeSelect = document.getElementById('recommendationType');
+      const minRatingSelect = document.getElementById('minGoogleRating');
+    
+      if (!target || !detectBtn || !searchBtn || !resetBtn) return;
+    
+      let lastCoords = null;
+      let lastResults = [];
+      let lastSearchLabel = '';
+    
+      const renderPlaces = (places) => {
+        target.innerHTML = places.length
+          ? places.map(place => this.renderGooglePlaceCard(place)).join('')
+          : this.emptyState('No nearby places matched the selected filters.');
+      };
+    
+      const reRenderFromCurrentResults = () => {
+        const minRating = parseFloat(minRatingSelect?.value || '0');
+        const filtered = this.filterGooglePlaces(lastResults, minRating);
+        renderPlaces(filtered);
+        if (lastResults.length) {
+          this.showMessage(
+            'recommendationStatus',
+            `Showing ${filtered.length} nearby place${filtered.length === 1 ? '' : 's'}${lastSearchLabel ? ` for ${lastSearchLabel}` : ''}.`,
+            'info'
+          );
+        }
+      };
+    
+      const currentRadius = () => parseInt(radiusSelect?.value || '8000', 10);
+      const currentTypes = () =>
+        (typeSelect?.value || 'restaurant,cafe')
+          .split(',')
+          .map(value => value.trim())
+          .filter(Boolean);
+    
+      const loadNearbyPlaces = async (coords, label = 'your location') => {
+        this.showMessage('recommendationStatus', `Loading nearby places for ${label}...`, 'info');
+    
+        try {
+          const results = await this.fetchNearbyGooglePlaces(coords, currentRadius(), currentTypes(), 12);
+          lastCoords = coords;
+          lastResults = results;
+          lastSearchLabel = label;
+          if (label === 'your location') this.setUserLocation(coords);
+    
+          reRenderFromCurrentResults();
+    
+          const visibleCount = this.filterGooglePlaces(results, parseFloat(minRatingSelect?.value || '0')).length;
+          this.showMessage(
+            'recommendationStatus',
+            `Loaded ${visibleCount} nearby place${visibleCount === 1 ? '' : 's'} for ${label}.`,
+            'success'
+          );
+        } catch (error) {
+          this.showMessage('recommendationStatus', error.message, 'error');
+          target.innerHTML = this.emptyState('Unable to load nearby places right now.');
+        }
+      };
+    
+      const loadManualLocation = async () => {
+        const address = manualInput?.value.trim();
+        if (!address) {
+          this.showMessage('recommendationStatus', 'Please enter a suburb, postcode, or address first.', 'error');
+          return;
+        }
+    
+        this.showMessage('recommendationStatus', `Looking up ${address}...`, 'info');
+    
+        try {
+          const payload = await this.searchGooglePlacesByAddress(address, currentRadius(), currentTypes(), 12);
+    
+          const coords = {
+            lat: payload.searchLocation.lat,
+            lng: payload.searchLocation.lng
+          };
+    
+          lastCoords = coords;
+          lastResults = payload.results || [];
+          lastSearchLabel = payload.searchLocation.formattedAddress || address;
+    
+          reRenderFromCurrentResults();
+    
+          const visibleCount = this.filterGooglePlaces(lastResults, parseFloat(minRatingSelect?.value || '0')).length;
+          this.showMessage(
+            'recommendationStatus',
+            `Loaded ${visibleCount} nearby place${visibleCount === 1 ? '' : 's'} for ${lastSearchLabel}.`,
+            'success'
+          );
+        } catch (error) {
+          this.showMessage('recommendationStatus', error.message, 'error');
+          target.innerHTML = this.emptyState('Unable to load nearby places for that location.');
+        }
+      };
+    
+      detectBtn.addEventListener('click', () => {
+        this.requestLocation('recommendationStatus', async coords => {
+          await loadNearbyPlaces(coords, 'your location');
+        });
+      });
+    
+      searchBtn.addEventListener('click', async () => {
+        await loadManualLocation();
+      });
+    
+      manualInput?.addEventListener('keydown', async (event) => {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          await loadManualLocation();
+        }
+      });
+    
+      resetBtn.addEventListener('click', () => {
+        lastCoords = null;
+        lastResults = [];
+        lastSearchLabel = '';
+        if (manualInput) manualInput.value = '';
+        target.innerHTML = this.emptyState('Use your current location or type another location to load live nearby recommendations.');
+        this.showMessage('recommendationStatus', 'Cleared nearby results.', 'info');
+      });
+    
+      minRatingSelect?.addEventListener('change', () => {
+        if (lastResults.length) reRenderFromCurrentResults();
+      });
+    
+      radiusSelect?.addEventListener('change', async () => {
+        if (lastCoords && lastSearchLabel) {
+          await loadNearbyPlaces(lastCoords, lastSearchLabel);
+        }
+      });
+    
+      typeSelect?.addEventListener('change', async () => {
+        if (lastCoords && lastSearchLabel) {
+          await loadNearbyPlaces(lastCoords, lastSearchLabel);
+        }
+      });
+    
+      target.innerHTML = this.emptyState('Use your current location or type another location to load live nearby recommendations.');
+      this.showMessage('recommendationStatus', 'Ready to search nearby places.', 'info');
+    },
+    
     async routePage() {
       const page = document.body.dataset.page;
       const routes = {
@@ -278,6 +426,100 @@
           <p class="mb-0 text-secondary">${review.content}</p>
         </div>
       `;
+    },
+
+    escapeHtml(value = '') {
+      return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#39;');
+    },
+
+    formatPlaceType(type = '') {
+      return type
+        .replaceAll('_', ' ')
+        .replace(/\b\w/g, char => char.toUpperCase());
+    },
+
+    googleMapsUrl(place) {
+      if (place.lat == null || place.lng == null) return '#';
+      return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${place.lat},${place.lng}`)}`;
+    },
+
+    async searchGooglePlacesByAddress(address, radius = 8000, includedTypes = ['restaurant', 'cafe'], maxResultCount = 12) {
+      const payload = await this.api('/api/google/search-location', {
+        method: 'POST',
+        body: {
+          address,
+          radius,
+          includedTypes,
+          maxResultCount
+        }
+      });
+    
+      return payload;
+    },
+
+    renderGooglePlaceCard(place) {
+      const tagHtml = (place.types || [])
+        .filter(type => !['point_of_interest', 'establishment', 'food', 'store'].includes(type))
+        .slice(0, 3)
+        .map(type => `<span class="badge badge-soft">${this.escapeHtml(this.formatPlaceType(type))}</span>`)
+        .join('');
+
+      return `
+        <div class="col-md-6 col-xl-4">
+          <div class="restaurant-card p-3 h-100">
+            <div class="restaurant-image mb-3">${this.escapeHtml(place.name || 'Nearby place')}</div>
+            <div class="d-flex flex-wrap mb-2">
+              <span class="rating-pill">⭐ ${place.rating ?? 'N/A'}</span>
+              <span class="cuisine-pill">${this.escapeHtml(this.formatPlaceType(place.primaryType || 'place'))}</span>
+            </div>
+            <h3 class="h5 fw-bold">${this.escapeHtml(place.name || 'Unnamed place')}</h3>
+            <p class="text-secondary mb-2">${this.escapeHtml(place.address || 'Address unavailable')}</p>
+            <div class="d-flex flex-wrap gap-2 mb-3">${tagHtml}</div>
+            <div class="d-flex gap-2">
+              <a class="btn btn-primary btn-sm" href="${this.googleMapsUrl(place)}" target="_blank" rel="noopener noreferrer">Open map</a>
+            </div>
+          </div>
+        </div>
+      `;
+    },
+
+    async fetchNearbyGooglePlaces(coords, radius = 8000, includedTypes = ['restaurant', 'cafe'], maxResultCount = 12) {
+      const payload = await this.api('/api/google/nearby', {
+        method: 'POST',
+        body: {
+          lat: coords.lat,
+          lng: coords.lng,
+          radius,
+          includedTypes,
+          maxResultCount
+        }
+      });
+
+      return payload.results || [];
+    },
+
+    filterGooglePlaces(places, minRating = 0) {
+      const blockedPrimaryTypes = new Set([
+        'gas_station',
+        'indoor_playground',
+        'playground',
+        'amusement_center'
+      ]);
+
+      return places.filter(place => {
+        const primaryType = (place.primaryType || '').toLowerCase();
+        const rating = Number(place.rating || 0);
+
+        if (blockedPrimaryTypes.has(primaryType)) return false;
+        if (rating < minRating) return false;
+
+        return true;
+      });
     },
 
     emptyState(message) {
@@ -615,43 +857,90 @@
       }
     },
 
-    initRecommendations() {
+    ommendations() {
       const target = document.getElementById('recommendationsGrid');
-      const render = (coords = null) => {
-        let items = this.attachDistance(this.state.restaurants, coords);
-        if (coords) {
-          const currentUser = this.getCurrentUser();
-          items = items.sort((left, right) => {
-            const distanceDiff = (left.distanceKm ?? 999) - (right.distanceKm ?? 999);
-            if (Math.abs(distanceDiff) > 0.15) return distanceDiff;
-            const leftBonus = currentUser && currentUser.preferredCuisine === left.cuisine ? 0.2 : 0;
-            const rightBonus = currentUser && currentUser.preferredCuisine === right.cuisine ? 0.2 : 0;
-            return (right.rating + rightBonus) - (left.rating + leftBonus);
-          });
-        } else {
-          items = items.sort((left, right) => right.rating - left.rating);
-        }
-        target.innerHTML = items.map(restaurant => this.renderRestaurantCard(restaurant)).join('');
-        this.bindSaveButtons();
+      const detectBtn = document.getElementById('detectLocationBtn');
+      const resetBtn = document.getElementById('resetRecommendationsBtn');
+      const radiusSelect = document.getElementById('recommendationRadius');
+      const typeSinitRecelect = document.getElementById('recommendationType');
+      const minRatingSelect = document.getElementById('minGoogleRating');
+
+      if (!target || !detectBtn || !resetBtn) return;
+
+      let lastCoords = null;
+      let lastResults = [];
+
+      const renderPlaces = (places) => {
+        target.innerHTML = places.length
+          ? places.map(place => this.renderGooglePlaceCard(place)).join('')
+          : this.emptyState('No nearby places matched the selected filters.');
       };
-      document.getElementById('detectLocationBtn').addEventListener('click', () => {
-        this.requestLocation('recommendationStatus', coords => {
+
+      const reRenderFromCurrentResults = () => {
+        const minRating = parseFloat(minRatingSelect?.value || '0');
+        const filtered = this.filterGooglePlaces(lastResults, minRating);
+        renderPlaces(filtered);
+        if (lastResults.length) {
+          this.showMessage('recommendationStatus', `Showing ${filtered.length} nearby place${filtered.length === 1 ? '' : 's'}.`, 'info');
+        }
+      };
+
+      const loadNearbyPlaces = async (coords) => {
+        const radius = parseInt(radiusSelect?.value || '8000', 10);
+        const includedTypes = (typeSelect?.value || 'restaurant,cafe')
+          .split(',')
+          .map(value => value.trim())
+          .filter(Boolean);
+
+        this.showMessage('recommendationStatus', 'Loading nearby places...', 'info');
+
+        try {
+          const results = await this.fetchNearbyGooglePlaces(coords, radius, includedTypes, 12);
+          lastCoords = coords;
+          lastResults = results;
           this.setUserLocation(coords);
-          this.showMessage('recommendationStatus', 'Location found. Nearby recommendations are now ranked from closest to furthest.', 'success');
-          render(coords);
+          reRenderFromCurrentResults();
+          const visibleCount = this.filterGooglePlaces(results, parseFloat(minRatingSelect?.value || '0')).length;
+          this.showMessage('recommendationStatus', `Loaded ${visibleCount} nearby place${visibleCount === 1 ? '' : 's'} from Google Places.`, 'success');
+        } catch (error) {
+          this.showMessage('recommendationStatus', error.message, 'error');
+          target.innerHTML = this.emptyState('Unable to load nearby places right now.');
+        }
+      };
+
+      detectBtn.addEventListener('click', () => {
+        this.requestLocation('recommendationStatus', async coords => {
+          await loadNearbyPlaces(coords);
         });
       });
-      document.getElementById('resetRecommendationsBtn').addEventListener('click', () => {
-        this.showMessage('recommendationStatus', 'Showing recommendations without distance sorting.', 'info');
-        render(null);
+
+      resetBtn.addEventListener('click', () => {
+        lastCoords = null;
+        lastResults = [];
+        target.innerHTML = this.emptyState('Click “Use my location” to load live nearby recommendations.');
+        this.showMessage('recommendationStatus', 'Cleared nearby results.', 'info');
       });
+
+      minRatingSelect?.addEventListener('change', () => {
+        if (lastResults.length) reRenderFromCurrentResults();
+      });
+
+      radiusSelect?.addEventListener('change', async () => {
+        if (lastCoords) await loadNearbyPlaces(lastCoords);
+      });
+
+      typeSelect?.addEventListener('change', async () => {
+        if (lastCoords) await loadNearbyPlaces(lastCoords);
+      });
+
       const saved = this.getUserLocation();
       if (saved) {
-        this.showMessage('recommendationStatus', 'Using your previously saved location.', 'info');
-        render(saved);
+        this.showMessage('recommendationStatus', 'Saved location found. Click “Use my location” to refresh live nearby places.', 'info');
       } else {
-        render(null);
+        this.showMessage('recommendationStatus', 'Click “Use my location” to fetch live nearby recommendations.', 'info');
       }
+
+      target.innerHTML = this.emptyState('Click “Use my location” to load live nearby recommendations.');
     },
 
     async initFavourites() {

--- a/bitescout_frontend/recommendations.html
+++ b/bitescout_frontend/recommendations.html
@@ -13,34 +13,77 @@
 <body data-page="recommendations">
   <div id="site-header"></div>
   <main>
-    
-<section class="py-5 page-banner border-bottom">
-  <div class="container">
-    <p class="eyebrow mb-2">Smart discovery</p>
-    <h1 class="fw-bold mb-3">Recommendations near you</h1>
-    <p class="text-secondary mb-0">Use geolocation to rank nearby restaurants and drinks spots based on your position, rating, and cuisine match.</p>
-  </div>
-</section>
-<section class="py-4">
-  <div class="container">
-    <div class="glass-card p-4 mb-4">
-      <div class="row g-3 align-items-center">
-        <div class="col-lg-8">
-          <h2 class="h4 fw-bold mb-2">Find nearby food and drink options</h2>
-          <p class="text-secondary mb-0">This uses the browser Geolocation API. For best results, run the site on localhost or a secure HTTPS host.</p>
-        </div>
-        <div class="col-lg-4 d-grid d-md-flex justify-content-lg-end gap-2">
-          <button id="detectLocationBtn" class="btn btn-primary">Use my location</button>
-          <button id="resetRecommendationsBtn" class="btn btn-outline-dark">Show all</button>
-        </div>
+
+    <section class="py-5 page-banner border-bottom">
+      <div class="container">
+        <p class="eyebrow mb-2">Smart discovery</p>
+        <h1 class="fw-bold mb-3">Recommendations near you</h1>
+        <p class="text-secondary mb-0">
+          Use your current location or type any suburb, postcode, or address to fetch nearby restaurants and cafes.
+        </p>
       </div>
-      <div id="recommendationStatus" class="mt-3"></div>
-    </div>
-    <div class="row g-4" id="recommendationsGrid"></div>
-  </div>
-</section>
+    </section>
+
+    <section class="py-4">
+      <div class="container">
+        <div class="glass-card p-4 mb-4">
+          <div class="row g-3 align-items-end">
+            <div class="col-lg-7">
+              <label for="manualLocationInput" class="form-label">Search another location</label>
+              <input
+                id="manualLocationInput"
+                type="text"
+                class="form-control"
+                placeholder="e.g. Bennett Springs WA, Victoria Park, 6063, 45 Rainbow Crescent Bennett Springs"
+              />
+            </div>
+            <div class="col-lg-5 d-grid d-md-flex gap-2">
+              <button id="searchLocationBtn" class="btn btn-outline-dark">Search this location</button>
+              <button id="detectLocationBtn" class="btn btn-primary">Use my location</button>
+              <button id="resetRecommendationsBtn" class="btn btn-outline-dark">Clear results</button>
+            </div>
+          </div>
+
+          <div class="row g-3 mt-2">
+            <div class="col-md-4">
+              <label for="recommendationRadius" class="form-label">Search radius</label>
+              <select id="recommendationRadius" class="form-select">
+                <option value="3000">3 km</option>
+                <option value="5000">5 km</option>
+                <option value="8000" selected>8 km</option>
+                <option value="12000">12 km</option>
+              </select>
+            </div>
+
+            <div class="col-md-4">
+              <label for="recommendationType" class="form-label">Type</label>
+              <select id="recommendationType" class="form-select">
+                <option value="restaurant,cafe" selected>Restaurants + cafes</option>
+                <option value="restaurant">Restaurants only</option>
+                <option value="cafe">Cafes only</option>
+              </select>
+            </div>
+
+            <div class="col-md-4">
+              <label for="minGoogleRating" class="form-label">Minimum rating</label>
+              <select id="minGoogleRating" class="form-select">
+                <option value="0">Any</option>
+                <option value="3">3+</option>
+                <option value="3.5">3.5+</option>
+                <option value="4">4+</option>
+              </select>
+            </div>
+          </div>
+
+          <div id="recommendationStatus" class="mt-3 small text-secondary"></div>
+        </div>
+
+        <div class="row g-4" id="recommendationsGrid"></div>
+      </div>
+    </section>
 
   </main>
+
   <div id="site-footer"></div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/data.js"></script>

--- a/routes.py
+++ b/routes.py
@@ -5,6 +5,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from . import db
 from .models import User, Restaurant, Dish, Review, FavouriteRestaurant, FavouriteDish
 
+
 bp = Blueprint('main', __name__)
 
 


### PR DESCRIPTION
## Summary
This PR adds live Google Places recommendations to BiteScout and extends the recommendations page so users can either use their current location or manually search another suburb, postcode, or address.

## What was added
- integrated Google Places nearby search into the Flask backend
- added manual location search through address geocoding
- updated the recommendations page UI with:
  - manual location input
  - search radius filter
  - place type filter
  - minimum rating filter
- connected the frontend recommendations flow to the backend API routes
- improved recommendation rendering so nearby places are shown as live result cards

## Backend changes
- added `/api/google/nearby` for browser geolocation-based search
- added `/api/google/search-location` for typed suburb/address/postcode search
- connected the backend to Google Places and geocoding helpers
- updated requirements/config needed for the Google API integration

## Frontend changes
- updated `recommendations.html`
- updated `app.js` to support:
  - current location search
  - manual location search
  - dynamic filtering of returned places
  - clearing and reloading recommendations

## Why this change
This improves BiteScout’s main discovery feature by making recommendations more flexible and useful. Users are no longer limited to only their current location and can search for food and drink options in any area they want to explore.

## Testing
- tested current-location search through `/api/google/nearby`
- tested manual address/suburb search through `/api/google/search-location`
- verified that nearby places are returned and rendered on the recommendations page