### PR TITLE
Add isolated unit tests, live-server Selenium E2E, and Windows-safe integration test cleanup

### DIFF
--- a/bitescout_backend/tests/e2e_server.py
+++ b/bitescout_backend/tests/e2e_server.py
@@ -1,0 +1,31 @@
+"""
+Standalone Flask process for Selenium end-to-end tests.
+
+Started via subprocess so the live server does not share the global SQLAlchemy
+instance with other tests running in the same interpreter.
+"""
+import os
+import sys
+
+BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from app import create_app  # noqa: E402
+
+
+def main() -> None:
+    port = int(os.environ["BITESCOUT_E2E_PORT"])
+    db_uri = os.environ["BITESCOUT_E2E_DB_URI"]
+    app = create_app(
+        {
+            "SQLALCHEMY_DATABASE_URI": db_uri,
+            "SECRET_KEY": "e2e-secret-key",
+            "TESTING": True,
+        }
+    )
+    app.run(host="127.0.0.1", port=port, use_reloader=False, threaded=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/bitescout_backend/tests/test_integration.py
+++ b/bitescout_backend/tests/test_integration.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-from app import create_app
+from app import create_app, db
 
 
 class BiteScoutIntegrationTests(unittest.TestCase):
@@ -19,6 +19,9 @@ class BiteScoutIntegrationTests(unittest.TestCase):
             )
 
             self.assertTrue(app.testing)
+            with app.app_context():
+                db.session.remove()
+                db.engine.dispose()
         finally:
             temp_dir.cleanup()
 
@@ -35,6 +38,9 @@ class BiteScoutIntegrationTests(unittest.TestCase):
                 )
 
             self.assertEqual(app.config["GOOGLE_MAPS_API_KEY"], "test-google-key")
+            with app.app_context():
+                db.session.remove()
+                db.engine.dispose()
         finally:
             temp_dir.cleanup()
 
@@ -50,7 +56,6 @@ class BiteScoutIntegrationTests(unittest.TestCase):
         self.client = self.app.test_client()
 
     def tearDown(self):
-        from app import db
         with self.app.app_context():
             db.session.remove()
             db.engine.dispose()

--- a/bitescout_backend/tests/test_selenium.py
+++ b/bitescout_backend/tests/test_selenium.py
@@ -1,50 +1,183 @@
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-import unittest
+"""
+Browser tests against a live Flask server (separate subprocess).
+
+Requires Google Chrome installed (Selenium 4 manages chromedriver).
+Run from repository backend folder, e.g.:
+
+  python -m unittest tests.test_selenium -v
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
 import time
+import unittest
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
 
-class SeleniumTests(unittest.TestCase):
+def _pick_free_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def _wait_for_http(url: str, timeout_s: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_err = None
+    while time.monotonic() < deadline:
+        try:
+            with urlopen(url, timeout=2) as response:
+                if response.status == 200:
+                    return
+        except (URLError, OSError) as exc:
+            last_err = exc
+        time.sleep(0.15)
+    raise RuntimeError(f"Server did not become ready at {url!r}: {last_err}")
+
+
+@unittest.skipUnless(
+    os.environ.get("SKIP_SELENIUM", "").lower() not in ("1", "true", "yes"),
+    "Set SKIP_SELENIUM=1 to skip browser tests",
+)
+class SeleniumLiveServerTests(unittest.TestCase):
+    """Selenium scenarios against a real http://127.0.0.1:<port> server process."""
+
+    driver = None
+    server_process = None
+    base_url = None
+    temp_dir = None
+
+    DEMO_EMAIL = "demo@bitescout.app"
+    DEMO_PASSWORD = "password123"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        db_path = Path(cls.temp_dir.name) / "selenium_e2e.db"
+        port = _pick_free_port()
+        cls.base_url = f"http://127.0.0.1:{port}"
+
+        env = os.environ.copy()
+        env["BITESCOUT_E2E_PORT"] = str(port)
+        env["BITESCOUT_E2E_DB_URI"] = f"sqlite:///{db_path.as_posix()}"
+        env["PYTHONUNBUFFERED"] = "1"
+
+        server_script = Path(__file__).resolve().parent / "e2e_server.py"
+        cls.server_process = subprocess.Popen(
+            [sys.executable, str(server_script)],
+            cwd=str(Path(__file__).resolve().parents[1]),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            _wait_for_http(f"{cls.base_url}/health", timeout_s=45.0)
+        except Exception:
+            cls._terminate_server()
+            stderr = ""
+            if cls.server_process.stderr:
+                stderr = cls.server_process.stderr.read().decode("utf-8", errors="replace")[:4000]
+            raise RuntimeError(f"E2E server failed to start. stderr tail:\n{stderr}") from None
+
+        options = webdriver.ChromeOptions()
+        options.add_argument("--headless=new")
+        options.add_argument("--disable-gpu")
+        options.add_argument("--window-size=1280,900")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        # DOM ready only; external fonts/CDN must not block tests on slow networks.
+        options.page_load_strategy = "eager"
+        cls.driver = webdriver.Chrome(options=options)
+        cls.driver.set_page_load_timeout(30)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.driver is not None:
+            cls.driver.quit()
+            cls.driver = None
+        cls._terminate_server()
+        if cls.temp_dir is not None:
+            cls.temp_dir.cleanup()
+            cls.temp_dir = None
+
+    @classmethod
+    def _terminate_server(cls):
+        proc = cls.server_process
+        if proc is None:
+            return
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        cls.server_process = None
 
     def setUp(self):
-        self.driver = webdriver.Chrome()
-        self.driver.get("http://127.0.0.1:5000")
+        self.driver.delete_all_cookies()
 
-    def tearDown(self):
-        self.driver.quit()
+    def _open(self, path: str):
+        if not path.startswith("/"):
+            path = "/" + path
+        url = f"{self.base_url}{path}"
+        try:
+            self.driver.get(url)
+        except TimeoutException:
+            self.driver.execute_script("window.stop();")
+
+        WebDriverWait(self.driver, 15).until(
+            lambda d: d.execute_script("return document.readyState") in ("interactive", "complete")
+        )
 
     def test_homepage_loads(self):
+        self._open("/")
         self.assertIn("BiteScout", self.driver.page_source)
+        self.assertIn("Find your next favorite bite", self.driver.page_source)
 
     def test_browse_page_loads(self):
-        self.driver.get("http://127.0.0.1:5000/browse.html")
+        self._open("/browse.html")
         self.assertIn("Restaurants near you", self.driver.page_source)
+        location = self.driver.find_element(By.ID, "locationInput")
+        self.assertTrue(location.is_displayed())
 
-    def test_login_flow(self):
-        self.driver.get("http://127.0.0.1:5000/login.html")
-
-        email_input = self.driver.find_element(By.NAME, "email")
-        password_input = self.driver.find_element(By.NAME, "password")
-
-        email_input.send_keys("bryantgu88@gmail.com")
-        password_input.send_keys("123456")
-
-        login_button = self.driver.find_element(By.CSS_SELECTOR, "button[type='submit']")
-        login_button.click()
-
-        time.sleep(2)
-
-        self.assertNotIn("Invalid", self.driver.page_source)
-        self.assertIn("BiteScout", self.driver.page_source)
+    def test_login_flow_redirects_to_profile(self):
+        self._open("/login.html")
+        wait = WebDriverWait(self.driver, 15)
+        self.driver.find_element(By.NAME, "email").send_keys(self.DEMO_EMAIL)
+        self.driver.find_element(By.NAME, "password").send_keys(self.DEMO_PASSWORD)
+        self.driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+        wait.until(EC.url_contains("profile.html"))
+        self.assertIn("profile", self.driver.current_url.lower())
 
     def test_signup_page_loads(self):
-        self.driver.get("http://127.0.0.1:5000/signup.html")
+        self._open("/signup.html")
         self.assertIn("Join BiteScout", self.driver.page_source)
 
-    def test_search_input_exists(self):
-        self.driver.get("http://127.0.0.1:5000/browse.html")
-        search = self.driver.find_element(By.TAG_NAME, "input")
-        self.assertIsNotNone(search)
+    def test_places_request_page_loads(self):
+        self._open("/places-request.html")
+        self.assertIn("Missing Place Requests", self.driver.page_source)
+
+    def test_health_endpoint_returns_ok(self):
+        self._open("/health")
+        body = self.driver.find_element(By.TAG_NAME, "body").text.lower()
+        self.assertTrue("ok" in body or "healthy" in body or "{" in body)
+
+    def test_browse_filter_controls_exist(self):
+        self._open("/browse.html")
+        wait = WebDriverWait(self.driver, 10)
+        rating_select = wait.until(EC.presence_of_element_located((By.ID, "ratingFilter")))
+        self.assertTrue(rating_select.is_displayed())
 
 
 if __name__ == "__main__":

--- a/bitescout_backend/tests/test_unit.py
+++ b/bitescout_backend/tests/test_unit.py
@@ -1,0 +1,86 @@
+"""Fast unit tests for pure helpers (no database or HTTP)."""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from app.google_places import (
+    GooglePlacesError,
+    dedupe_places,
+    get_api_key,
+    nearby_payload,
+    place_to_result,
+)
+
+
+class GooglePlacesUnitTests(unittest.TestCase):
+    def test_place_to_result_maps_display_name_and_location(self):
+        place = {
+            "id": "places/x",
+            "displayName": {"text": "Test Cafe"},
+            "formattedAddress": "1 Main St",
+            "location": {"latitude": -31.95, "longitude": 115.86},
+            "rating": 4.2,
+            "primaryType": "cafe",
+            "types": ["cafe", "food"],
+            "photos": [{"name": "places/x/photos/p1", "authorAttributions": []}],
+            "websiteUri": "https://example.com",
+            "googleMapsUri": "https://maps.example.com",
+        }
+        result = place_to_result(place)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["name"], "Test Cafe")
+        self.assertEqual(result["lat"], -31.95)
+        self.assertEqual(result["lng"], 115.86)
+        self.assertEqual(result["photoName"], "places/x/photos/p1")
+        self.assertEqual(result["source"], "google_places")
+
+    def test_place_to_result_returns_none_for_blocked_primary_type(self):
+        place = {
+            "id": "places/gas",
+            "displayName": {"text": "Gas Stop"},
+            "primaryType": "gas_station",
+            "location": {"latitude": 0, "longitude": 0},
+        }
+        self.assertIsNone(place_to_result(place))
+
+    def test_dedupe_places_removes_duplicates_and_respects_limit(self):
+        places = [
+            {"id": "a", "name": "One"},
+            {"id": "a", "name": "Dup"},
+            {"id": "b", "name": "Two"},
+            {"id": "c", "name": "Three"},
+        ]
+        out = dedupe_places(places, 2)
+        self.assertEqual([p["id"] for p in out], ["a", "b"])
+
+    def test_dedupe_places_skips_entries_without_id(self):
+        places = [{}, {"id": "", "name": "Empty"}, {"id": "z", "name": "Ok"}]
+        out = dedupe_places(places, 10)
+        self.assertEqual([p["id"] for p in out], ["z"])
+
+    def test_nearby_payload_includes_circle_and_optional_types(self):
+        payload = nearby_payload(-31.0, 116.0, 5000, ["cafe", "restaurant"], 12)
+        self.assertEqual(payload["maxResultCount"], 12)
+        self.assertEqual(payload["includedTypes"], ["cafe", "restaurant"])
+        center = payload["locationRestriction"]["circle"]["center"]
+        self.assertEqual(center["latitude"], -31.0)
+        self.assertEqual(center["longitude"], 116.0)
+        self.assertEqual(payload["locationRestriction"]["circle"]["radius"], 5000.0)
+
+    def test_nearby_payload_omits_included_types_when_empty(self):
+        payload = nearby_payload(0, 0, 1000, [], 5)
+        self.assertNotIn("includedTypes", payload)
+
+    def test_get_api_key_accepts_explicit_value(self):
+        self.assertEqual(get_api_key("my-key"), "my-key")
+
+    def test_get_api_key_raises_when_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(GooglePlacesError) as ctx:
+                get_api_key(None)
+        self.assertIn("GOOGLE_MAPS_API_KEY", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR strengthens automated testing so it clearly meets expectations for **unit tests**, **Selenium / browser tests**, and **running against a live server**.

## What changed

### `tests/test_unit.py`
- Adds **eight** unit tests for pure helpers in `app.google_places` (`place_to_result`, blocked primary types, `dedupe_places`, `nearby_payload`, `get_api_key` error path).
- No database or HTTP; fast and isolated.

### `tests/e2e_server.py` + `tests/test_selenium.py`
- Selenium runs against a **real Flask app** in a **separate subprocess** (dedicated SQLite DB + ephemeral port), instead of assuming something is already on port 5000.
- Uses documented **demo** login (`demo@bitescout.app` / `password123`).
- Headless Chrome with more resilient navigation (eager page load, `window.stop()` on load timeout, then wait for `document.readyState`) so CDN/fonts do not hang the suite.

### `tests/test_integration.py`
- Fixes **Windows** `PermissionError` on temp DB cleanup by **disposing** the SQLAlchemy engine before deleting the temp directory in the two “create app only” tests.
- Uses a single `db` import for teardown consistency.

## How to verify

From `bitescout_backend`:

```bash
python -m unittest discover -s tests -p "test_*.py" --buffer