### PR TITLE
Test/selenium stability

### DIFF
--- a/bitescout_backend/tests/test_selenium.py
+++ b/bitescout_backend/tests/test_selenium.py
@@ -1,14 +1,20 @@
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+import os
 import unittest
 import time
+
+
+BASE_URL = os.getenv("BITESCOUT_BASE_URL", "http://127.0.0.1:5000")
+TEST_EMAIL = os.getenv("BITESCOUT_TEST_EMAIL", "demo@bitescout.app")
+TEST_PASSWORD = os.getenv("BITESCOUT_TEST_PASSWORD", "password123")
 
 
 class SeleniumTests(unittest.TestCase):
 
     def setUp(self):
         self.driver = webdriver.Chrome()
-        self.driver.get("http://127.0.0.1:5000")
+        self.driver.get(BASE_URL)
 
     def tearDown(self):
         self.driver.quit()
@@ -17,17 +23,17 @@ class SeleniumTests(unittest.TestCase):
         self.assertIn("BiteScout", self.driver.page_source)
 
     def test_browse_page_loads(self):
-        self.driver.get("http://127.0.0.1:5000/browse.html")
+        self.driver.get(f"{BASE_URL}/browse.html")
         self.assertIn("Restaurants near you", self.driver.page_source)
 
     def test_login_flow(self):
-        self.driver.get("http://127.0.0.1:5000/login.html")
+        self.driver.get(f"{BASE_URL}/login.html")
 
         email_input = self.driver.find_element(By.NAME, "email")
         password_input = self.driver.find_element(By.NAME, "password")
 
-        email_input.send_keys("bryantgu88@gmail.com")
-        password_input.send_keys("123456")
+        email_input.send_keys(TEST_EMAIL)
+        password_input.send_keys(TEST_PASSWORD)
 
         login_button = self.driver.find_element(By.CSS_SELECTOR, "button[type='submit']")
         login_button.click()
@@ -38,11 +44,11 @@ class SeleniumTests(unittest.TestCase):
         self.assertIn("BiteScout", self.driver.page_source)
 
     def test_signup_page_loads(self):
-        self.driver.get("http://127.0.0.1:5000/signup.html")
+        self.driver.get(f"{BASE_URL}/signup.html")
         self.assertIn("Join BiteScout", self.driver.page_source)
 
     def test_search_input_exists(self):
-        self.driver.get("http://127.0.0.1:5000/browse.html")
+        self.driver.get(f"{BASE_URL}/browse.html")
         search = self.driver.find_element(By.TAG_NAME, "input")
         self.assertIsNotNone(search)
 

--- a/bitescout_backend/tests/test_selenium.py
+++ b/bitescout_backend/tests/test_selenium.py
@@ -1,8 +1,9 @@
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 import os
 import unittest
-import time
 
 
 BASE_URL = os.getenv("BITESCOUT_BASE_URL", "http://127.0.0.1:5000")
@@ -14,6 +15,7 @@ class SeleniumTests(unittest.TestCase):
 
     def setUp(self):
         self.driver = webdriver.Chrome()
+        self.wait = WebDriverWait(self.driver, 5)
         self.driver.get(BASE_URL)
 
     def tearDown(self):
@@ -38,10 +40,8 @@ class SeleniumTests(unittest.TestCase):
         login_button = self.driver.find_element(By.CSS_SELECTOR, "button[type='submit']")
         login_button.click()
 
-        time.sleep(2)
-
-        self.assertNotIn("Invalid", self.driver.page_source)
-        self.assertIn("BiteScout", self.driver.page_source)
+        self.wait.until(EC.url_contains("profile.html"))
+        self.assertIn("profile.html", self.driver.current_url)
 
     def test_signup_page_loads(self):
         self.driver.get(f"{BASE_URL}/signup.html")

--- a/bitescout_backend/tests/test_selenium.py
+++ b/bitescout_backend/tests/test_selenium.py
@@ -49,7 +49,7 @@ class SeleniumTests(unittest.TestCase):
 
     def test_search_input_exists(self):
         self.driver.get(f"{BASE_URL}/browse.html")
-        search = self.driver.find_element(By.TAG_NAME, "input")
+        search = self.driver.find_element(By.ID, "locationInput")
         self.assertIsNotNone(search)
 
 


### PR DESCRIPTION
## Summary

- Replace hard-coded personal Selenium login credentials with configurable test settings and the seeded demo account
- Use explicit waits for the login redirect instead of a fixed sleep
- Target the browse page location input by its stable element id

## Why

This makes the Selenium tests easier to run on other machines and reduces false positives in the login flow. It also keeps the test account data reproducible for future contributors.

Related to #19.

## Validation

- `python -m unittest tests/test_integration.py`
- `python -m unittest tests/test_selenium.py`